### PR TITLE
Blinky: Remove unused variable

### DIFF
--- a/samples/Blinky/Blinky/Program.cs
+++ b/samples/Blinky/Blinky/Program.cs
@@ -11,8 +11,6 @@ namespace Blinky
 {
 	public class Program
     {
-        static GpioPinValue _pin = GpioPinValue.High;
-
         public static void Main()
         {
             // pick a board, uncomment one line for GpioPin; default is STM32F769I_DISCO


### PR DESCRIPTION
Probably left over from the days, when `.Toggle()` was either not implemented or simply not used.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
