### PR TITLE
Fix output of frequency and period in GpioChangeCounter sample

### DIFF
--- a/samples/Gpio/GpioChangeCounter/GpioChangeCounter/Program.cs
+++ b/samples/Gpio/GpioChangeCounter/GpioChangeCounter/Program.cs
@@ -115,10 +115,10 @@ namespace ChangeCounter
 
                 // Sleep is not accurate so calculate actual time in secounds based of relative time differences of the 2 counts
                 // Ticks are in 100 nano sec increments
-                double periodSecs = (double)(countEnd.RelativeTime.Ticks - countStart.RelativeTime.Ticks)/10000000.0;
+                double periodSecs = (double)(countEnd.RelativeTime.Ticks - countStart.RelativeTime.Ticks)/10000000000.0;
                 int frequecy = (int)((double)countEnd.Count / periodSecs);
 
-                Console.WriteLine($"Period {periodSecs:F6} Frequency {frequecy}");
+                Console.WriteLine($"Period {periodSecs:F6} Sec | Frequency {frequecy} Hz");
             }
         }
 


### PR DESCRIPTION
## Description
- Correct calculation of Period.
- Added units to the output prints.

## Motivation and Context
- To fix the Frequency indication on print outputs. With the original version, frequency printed is 1 and should be around 1234 Hz.

## How Has This Been Tested?<!-- (if applicable) -->
Tested by deploy run GpioChangeCounter sample to ESP32 DEV KIT v1
Following the instructions of this sample.
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a sample)
- [x] Bug fix (fixes an issue with a current sample)
- [ ] New Sample (adds a new sample)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
