### PR TITLE
Edited Blinky to run with latest Gpio API

### DIFF
--- a/samples/Blinky/Blinky/Blinky.nfproj
+++ b/samples/Blinky/Blinky/Blinky.nfproj
@@ -22,8 +22,18 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
     <Reference Include="mscorlib, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.9.1-preview.6\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
@@ -34,6 +44,11 @@
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.14\lib\System.Device.Gpio.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2-preview.21\lib\Windows.Devices.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/samples/Blinky/Blinky/Program.cs
+++ b/samples/Blinky/Blinky/Program.cs
@@ -1,11 +1,6 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// See LICENSE file in the project root for full license information.
-//
-
-using System.Device.Gpio;
-using System;
+﻿using System;
 using System.Threading;
+using Windows.Devices.Gpio;
 
 namespace Blinky
 {
@@ -25,7 +20,7 @@ namespace Blinky
             //GpioPin led = GpioController.GetDefault().OpenPin(4);
 
             // F429I_DISCO: PG14 is LEDLD4 
-            //GpioPin led = GpioController.GetDefault().OpenPin(PinNumber('G', 14));
+            GpioPin led = GpioController.GetDefault().OpenPin(PinNumber('G', 14));
 
             // NETDUINO 3 Wifi: A10 is LED onboard blue
             // GpioPin led = GpioController.GetDefault().OpenPin(PinNumber('A', 10));
@@ -40,9 +35,7 @@ namespace Blinky
             //GpioPin led = GpioController.GetDefault().OpenPin(PinNumber('B', 7));
 
             // STM32F769I_DISCO: PJ5 is LD2
-            GpioPin led = s_GpioController.OpenPin(
-                PinNumber('J', 5),
-                PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('J', 5));
 
             // STM32L072Z_LRWAN1: PA5 is LD2
             //GpioPin led = GpioController.GetDefault().OpenPin(PinNumber('A', 5));
@@ -56,8 +49,9 @@ namespace Blinky
             // ULX3S FPGA board: for the red D22 LED from the ESP32-WROOM32, GPIO5
             //GpioPin led = GpioController.GetDefault().OpenPin(5);
 
+            led.SetDriveMode(GpioPinDriveMode.Output);
 
-            led.Write(PinValue.Low);
+            led.Write(GpioPinValue.Low);
 
             while (true)
             {

--- a/samples/Blinky/Blinky/packages.config
+++ b/samples/Blinky/Blinky/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.9.1-preview.6" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.8.2-preview.10" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2-preview.21" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
## Description
Gpio port bound to led should be explicitly set as Output mode pin