### PR TITLE
Fix platform detection for Storage ESP32

### DIFF
--- a/samples/Storage/FileAccess/Program.cs
+++ b/samples/Storage/FileAccess/Program.cs
@@ -136,7 +136,7 @@ namespace FileAccess
         /// </remarks>
         static bool DeviceNeedsMounting()
         {
-            return (SystemInfo.OEMString.IndexOf("ESP32") >= 0);
+            return (SystemInfo.Platform.IndexOf("ESP32") >= 0);
         }
     }
 }


### PR DESCRIPTION
## Description

Fix platform detection for Storage ESP32

## Motivation and Context

- Fixes the platform detection from OEMString to Platform

## How Has This Been Tested?

Through running the sample on an ESP32

## Types of changes

- [ ] Improvement (non-breaking change that improves a sample)
- [x] Bug fix (fixes an issue with a current sample)
- [ ] New Sample (adds a new sample)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: Ellerbach <laurelle@microsoft.com>
