### PR TITLE
Update strip the device name from SAS token

### DIFF
--- a/samples/HTTP/HttpAzureGET/Program.cs
+++ b/samples/HTTP/HttpAzureGET/Program.cs
@@ -74,7 +74,7 @@ namespace HttpSamples.HttpAzureGET
             var to = sas.IndexOf(".");
             string iotHubName = sas.Substring(from, to - from);
             // strip the deviceName from the SAS
-            to = sas.IndexOf("1&") + 1;
+            to = sas.IndexOf("&");
             from = sas.IndexOf("%2Fdevices%2F") + 13;
             string deviceName = sas.Substring(from, to - from);
 

--- a/samples/HTTP/HttpAzurePOST/Program.cs
+++ b/samples/HTTP/HttpAzurePOST/Program.cs
@@ -78,7 +78,7 @@ namespace HttpSamples.HttpAzurePOST
             var to = sas.IndexOf(".");
             string iotHubName = sas.Substring(from, to - from);
             // strip the deviceName from the SAS
-            to = sas.IndexOf("1&") + 1;
+            to = sas.IndexOf("&");
             from = sas.IndexOf("%2Fdevices%2F") + 13;
             string deviceName = sas.Substring(from, to - from);
 


### PR DESCRIPTION
## Description
In code implementation, device name extraction was looking for an additional character which is not part of SAS Token anymore.
Removed that character and updated strip line

## Motivation and Context
This small change helps to strip device name correctly

## How Has This Been Tested?<!-- (if applicable) -->
Build and deployed the code to ESP32 device

## Types of changes
Change the strip line works with SAS token