### PR TITLE
add Feather S2 to Blinky sample

### DIFF
--- a/samples/Blinky/Blinky/Program.cs
+++ b/samples/Blinky/Blinky/Program.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace Blinky
 {
-	public class Program
+    public class Program
     {
         private static GpioController s_GpioController;
         public static void Main()
@@ -19,70 +19,46 @@ namespace Blinky
             // pick a board, uncomment one line for GpioPin; default is STM32F769I_DISCO
 
             // DISCOVERY4: PD15 is LED6 
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('D', 15),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('D', 15), PinMode.Output);
 
             // ESP32 DevKit: 4 is a valid GPIO pin in, some boards like Xiuxin ESP32 may require GPIO Pin 2 instead.
-            //GpioPin led = s_GpioController.OpenPin(
-            //4,
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(4, PinMode.Output);
+
+            // FEATHER S2: 
+            //GpioPin led = s_GpioController.OpenPin(13, PinMode.Output);
 
             // F429I_DISCO: PG14 is LEDLD4 
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('G', 14),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('G', 14), PinMode.Output);
 
             // NETDUINO 3 Wifi: A10 is LED onboard blue
-            // GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('A', 10),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('A', 10), PinMode.Output);
 
             // QUAIL: PE15 is LED1  
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('E', 15),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('E', 15), PinMode.Output);
 
             // STM32F091RC: PA5 is LED_GREEN
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('A', 5),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('A', 5), PinMode.Output);
 
             // STM32F746_NUCLEO: PB75 is LED2
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('B', 7),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('B', 7), PinMode.Output);
 
             //STM32F769I_DISCO: PJ5 is LD2
-            //GpioPin led = s_GpioController.OpenPin(
-            //    PinNumber('J', 5),
-            //    PinMode.Output);
+            GpioPin led = s_GpioController.OpenPin(PinNumber('J', 5), PinMode.Output);
 
             // ST_B_L475E_IOT01A: PB14 is LD2
-            GpioPin led = s_GpioController.OpenPin(
-                PinNumber('B', 14),
-                PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('B', 14), PinMode.Output);
 
             // STM32L072Z_LRWAN1: PA5 is LD2
-            //GpioPin led = s_GpioController.OpenPin(
-            //PinNumber('A', 5),
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(PinNumber('A', 5), PinMode.Output);
 
             // TI CC13x2 Launchpad: DIO_07 it's the green LED
-            //GpioPin led = s_GpioController.OpenPin(
-            //7,
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(7, PinMode.Output);
 
             // TI CC13x2 Launchpad: DIO_06 it's the red LED  
-            //GpioPin led = s_GpioController.OpenPin(
-            //6,
-            //PinMode.Output);
+            //GpioPin led = s_GpioController.OpenPin(6, PinMode.Output);
 
             // ULX3S FPGA board: for the red D22 LED from the ESP32-WROOM32, GPIO5
-            //GpioPin led = s_GpioController.OpenPin(
-            //5,
-            //PinMode.Output);
-
+            //GpioPin led = s_GpioController.OpenPin(5, PinMode.Output);
 
             led.Write(PinValue.Low);
 


### PR DESCRIPTION
## Description
- add GpioPin definition for FEATHER S2, it uses pin IO13
- to improve readability and to match the instruction 'pick a board, uncomment one line', put each on one line

## Motivation and Context
extends Blinky to support FEATHER S2

## How Has This Been Tested?<!-- (if applicable) -->
Tested against FeatherS2, flashes device blue LED.
Device currently requires 'preview' libraries, this change not included in this request though it would not be possible for user to deploy to device without updating nuget. 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a sample)
- [ ] Bug fix (fixes an issue with a current sample)
- [ ] New Sample (adds a new sample)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
