### PR TITLE
Added LED GPIO config for Sparkfun ESP32 Thing Plus, RAK11200 on RAK5005/RAK1907/RAK19001

### DIFF
--- a/samples/Blinky/Blinky/Program.cs
+++ b/samples/Blinky/Blinky/Program.cs
@@ -7,6 +7,8 @@ using System.Device.Gpio;
 using System;
 using System.Threading;
 
+//using nanoFramework.Hardware.Esp32;
+
 namespace Blinky
 {
     public class Program
@@ -63,6 +65,15 @@ namespace Blinky
             // Silabs SLSTK3701A: LED1 PH14 is LLED1
             //GpioPin led = s_GpioController.OpenPin(PinNumber('H', 14), PinMode.Output);
 
+            // Sparkfun Thing Plus - ESP32 WROOM 
+            //GpioPin led = s_GpioController.OpenPin(Gpio.IO13, PinMode.Output);
+
+            // RAK11200 on RAK5005/RAK19001/19007. The RAK19001 needs battery connected or power switch in rechargeable position
+            //GpioPin led = s_GpioController.OpenPin(Gpio.IO12, PinMode.Output); // LED1 Green
+            //GpioPin led = s_GpioController.OpenPin(Gpio.IO02, PinMode.Output); // LED2 Blue
+
+            // RAK2305 
+            //GpioPin led = s_GpioController.OpenPin(Gpio.IO18, PinMode.Output); // LED Green (Test LED) on device
 
             led.Write(PinValue.Low);
 


### PR DESCRIPTION
…005/RAK19007/RAK19001 base boards, and RAK2305

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added configuration for RAK11200 Core and RAK2305 Wireless modules, all commented out. Note about making RAK11200 work on RAK19001

## Motivation and Context
Adds more Blinky device configurations to make it easier for first time users of nanoFramework to get started.

## How Has This Been Tested?<!-- (if applicable) -->
Tested with RAK2305 confirmed onboard green LED flashes. Tested RAK11200 on RAK5005/RAK19007/RAK19001 base boards confirmed blue/green LEDs flashed.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Improvement (non-breaking change that improves a sample)
- [ ] Bug fix (fixes an issue with a current sample)
- [ ] New Sample (adds a new sample)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
