### PR TITLE
Add first sample for OpenThread

### DIFF
--- a/samples/OpenThread/Display.cs
+++ b/samples/OpenThread/Display.cs
@@ -1,4 +1,9 @@
-﻿using nanoFramework.Networking.Thread;
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.Networking.Thread;
 using System;
 using System.Text;
 

--- a/samples/OpenThread/Display.cs
+++ b/samples/OpenThread/Display.cs
@@ -1,0 +1,54 @@
+﻿using nanoFramework.Networking.Thread;
+using System;
+using System.Text;
+
+namespace Samples
+{
+    internal class Display
+    {
+        public static string LH
+        {
+            get { return DateTime.UtcNow.ToString("HH:mm:ss") + "-"; }
+        }
+
+        public static void Log(string str)
+        {
+            Console.WriteLine($"{LH} {str}");
+        }
+
+        public static void Log(string[] strings)
+        {
+            foreach (string line in strings)
+            {
+                Log(line);
+            }
+        }
+
+        public static void Role(ThreadDeviceRole role)
+        {
+            switch (role)
+            {
+                case ThreadDeviceRole.Child: Log("Role = Child"); break;
+                case ThreadDeviceRole.Router: Log("Role = Router"); break;
+                case ThreadDeviceRole.Leader: Log("Role = Leader"); break;
+                case ThreadDeviceRole.Detached: Log("Role = Detached"); break;
+                case ThreadDeviceRole.Disabled: Log("Role = Disabled"); break;
+                default:
+                    Log($"Role is {role}");
+                    break;
+            }
+        }
+
+        public static void LogMemoryStats(string info)
+        {
+            uint manMem = nanoFramework.Runtime.Native.GC.Run(true);
+
+            uint total;
+            uint free;
+            uint largest;
+
+            nanoFramework.Hardware.Esp32.NativeMemory.GetMemoryInfo(nanoFramework.Hardware.Esp32.NativeMemory.MemoryType.All, out total, out free, out largest);
+            Console.WriteLine($"{LH} Memory All ({info}) Managed:{manMem} Native total:{total}/Free:{free}/Largest:{largest}");
+        }
+    }
+}

--- a/samples/OpenThread/Led.cs
+++ b/samples/OpenThread/Led.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Drawing;
+using System.Threading;
+using nanoFramework.Runtime.Native;
+using CCSWE.nanoFramework.NeoPixel;
+using CCSWE.nanoFramework.NeoPixel.Drivers;
+using nanoFramework.Networking.Thread;
+
+namespace Samples
+{
+    public class Led
+    {
+        private NeoPixelStrip _led;
+        private ThreadDeviceRole _role;
+
+        /// <summary>
+        /// Open _led for inbuilt Neopixel
+        /// </summary>
+        public Led()
+        {
+            if (SystemInfo.TargetName.Contains("ESP32_H2") || SystemInfo.TargetName.Contains("ESP32_C6"))
+            {
+                var driver = new Ws2812B(CCSWE.nanoFramework.NeoPixel.ColorOrder.GRB);
+                _led = new NeoPixelStrip(8, 1, driver);
+            }
+            else
+            {
+                _led = null;
+            }
+        }
+
+        public void SetRxTX()
+        {
+            Set(_role, 0.2d);
+            Thread.Sleep(50);
+            Set(_role, 0.1d);
+        }
+
+        public void Set(ThreadDeviceRole role)
+        {
+            Set(role, 0.1d);
+        }
+
+        private void Set(ThreadDeviceRole role, double brightness)
+        {
+            Color col;
+
+            if (_led == null)
+            {
+                return;
+            }
+
+            // Save it for RXTX
+            _role = role;
+
+            switch (role)
+            {
+                case ThreadDeviceRole.Detached:
+                    col = Color.White;
+                    break;
+
+                case ThreadDeviceRole.Child:
+                    col = Color.Green;
+                    break;
+
+                case ThreadDeviceRole.Router:
+                    col = Color.Blue;
+                    break;
+
+                case ThreadDeviceRole.Leader:
+                    col = Color.Red;
+                    break;
+
+                case ThreadDeviceRole.Disabled:
+                default:
+                    col = Color.Black;
+                    brightness = 0;
+                    break;
+            }
+
+            _led.SetLed(0, col, brightness);
+            _led.Update();
+        }
+    }
+}

--- a/samples/OpenThread/Led.cs
+++ b/samples/OpenThread/Led.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.Drawing;
 using System.Threading;
 using nanoFramework.Runtime.Native;
@@ -31,17 +36,17 @@ namespace Samples
 
         public void SetRxTX()
         {
-            Set(_role, 0.2d);
+            Set(_role, 0.2f);
             Thread.Sleep(50);
-            Set(_role, 0.1d);
+            Set(_role, 0.1f);
         }
 
         public void Set(ThreadDeviceRole role)
         {
-            Set(role, 0.1d);
+            Set(role, 0.1f);
         }
 
-        private void Set(ThreadDeviceRole role, double brightness)
+        private void Set(ThreadDeviceRole role, float brightness)
         {
             Color col;
 

--- a/samples/OpenThread/README.md
+++ b/samples/OpenThread/README.md
@@ -1,0 +1,82 @@
+# 🌶️🌶️ - OpenTHread Networking sample pack
+
+Shows how to use OpenThread Networking API.
+
+## Samples
+
+- [🌶️🌶️🌶️ - UPD OpenThread Client using sockets](UdpThreadClient/)
+- [🌶️🌶️🌶️ - UPD OpenThread Server using sockets](UdpThreadServer/)
+
+Shows how to use various APIs related to OpenThread.
+
+> **Note:** This sample is part of a large collection of nanoFramework feature samples.
+> If you are unfamiliar with Git and GitHub, you can download the entire collection as a
+> [ZIP file](https://github.com/nanoframework/Samples/archive/main.zip), but be
+> sure to unzip everything to access any shared dependencies.
+<!-- For more info on working with the ZIP file, 
+> the samples collection, and GitHub, see [Get the UWP samples from GitHub](https://aka.ms/ovu2uq). 
+> For more samples, see the [Samples portal](https://aka.ms/winsamples) on the Windows Dev Center.  -->
+
+## Hardware requirements
+
+These project are for the ESP32_C6 and ESP32_H2 Espressif devkit boards with a Ws2812B Neopixel on pin 8. 
+This can be easily disabled or Ws2812B added to pin 8 for other boards.
+
+## Sample description
+
+### Upd socket samples
+
+These 2 sample work together to create a client / server communications over OpenThread.
+They use UPD sockets over the IPV6 networking of the OpenThread stack.
+
+The neopixel shows the current role of the node.
+- White -> Detached from network
+- Green -> Child
+- Blue  -> Router
+- Red   -> Leader
+ 
+ The led will flash when message is transmitted or received.
+
+ The samples use the CCSWE.nanoFramework.Neopixel for driving the neopixels.
+ 
+ There is currently a problem driving the RMT on the ESP32_H2 devices as the core frequency for RMT is
+ 32Mhz instead of 80Mhz. This will be fixed shortly.
+
+#### UdpThreadClient
+This sample will send a broadcast message every 5 seconds using the built-in mesh broadcast address "ff03::1" and port 12324.
+Any UdpThreadServer running on the same mesh network will receive message and respond back to sender. 
+Any received messages are logged on console.
+
+#### UdpThreadServer
+Sample opens sockets and waits for any messages on port 1234. If any message is received to is echoed back to sending address.
+
+
+## Related topics
+
+### Reference
+
+- [nanoFramework.Networking.Thread](http://docs.nanoframework.net/api/nanoFramework.Networking.Thread)
+
+## Build the sample
+
+1. Start Microsoft Visual Studio 2022 or Visual Studio 2019 (Visual Studio 2017 should be OK too) and select `File > Open > Project/Solution`.
+1. Starting in the folder where you unzipped the samples/cloned the repository, go to the subfolder for this specific sample. Double-click the Visual Studio Solution (.sln) file.
+1. Press `Ctrl+Shift+B`, or select `Build > Build Solution`.
+
+## Run the sample
+
+The next steps depend on whether you just want to deploy the sample or you want to both deploy and run it.
+
+### Deploying the sample
+
+- Select `Build > Deploy Solution`.
+
+### Deploying and running the sample
+
+- To debug the sample and then run it, press F5 or select `Debug > Start Debugging`.
+
+> [!NOTE]
+>
+> **Important**: Before deploying or running the sample, please make sure your device is visible in the Device Explorer.
+>
+> **Tip**: To display the Device Explorer, go to Visual Studio menus: `View > Other Windows > Device Explorer`.

--- a/samples/OpenThread/README.md
+++ b/samples/OpenThread/README.md
@@ -9,14 +9,6 @@ Shows how to use OpenThread Networking API.
 
 Shows how to use various APIs related to OpenThread.
 
-> **Note:** This sample is part of a large collection of nanoFramework feature samples.
-> If you are unfamiliar with Git and GitHub, you can download the entire collection as a
-> [ZIP file](https://github.com/nanoframework/Samples/archive/main.zip), but be
-> sure to unzip everything to access any shared dependencies.
-<!-- For more info on working with the ZIP file, 
-> the samples collection, and GitHub, see [Get the UWP samples from GitHub](https://aka.ms/ovu2uq). 
-> For more samples, see the [Samples portal](https://aka.ms/winsamples) on the Windows Dev Center.  -->
-
 ## Hardware requirements
 
 These project are for the ESP32_C6 and ESP32_H2 Espressif devkit boards with a Ws2812B Neopixel on pin 8. 
@@ -30,6 +22,7 @@ These 2 sample work together to create a client / server communications over Ope
 They use UPD sockets over the IPV6 networking of the OpenThread stack.
 
 The neopixel shows the current role of the node.
+
 - White -> Detached from network
 - Green -> Child
 - Blue  -> Router
@@ -43,13 +36,14 @@ The neopixel shows the current role of the node.
  32Mhz instead of 80Mhz. This will be fixed shortly.
 
 #### UdpThreadClient
+
 This sample will send a broadcast message every 5 seconds using the built-in mesh broadcast address "ff03::1" and port 12324.
 Any UdpThreadServer running on the same mesh network will receive message and respond back to sender. 
 Any received messages are logged on console.
 
 #### UdpThreadServer
-Sample opens sockets and waits for any messages on port 1234. If any message is received to is echoed back to sending address.
 
+Sample opens sockets and waits for any messages on port 1234. If any message is received to is echoed back to sending address.
 
 ## Related topics
 

--- a/samples/OpenThread/SocketUtils.cs
+++ b/samples/OpenThread/SocketUtils.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Net;
+using System.Text;
+
+namespace Samples
+{
+    internal class NetUtils
+    {
+        private static Socket socket;
+
+        /// <summary>
+        ///  Open a new UDP socket
+        /// </summary>
+        /// <param name="remoteAdr"></param>
+        /// <param name="port"></param>
+        public static void OpenUdpSocket(String remoteAdr, int port, IPAddress endpoint)
+        {
+            socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
+
+            // Interface / port to receive on
+            IPEndPoint ep = new IPEndPoint(endpoint, port);
+            socket.Bind(ep);
+
+            if (remoteAdr.Length > 0)
+            {
+                // Set remote address
+                var address = IPAddress.Parse(remoteAdr);
+                IPEndPoint rep = new IPEndPoint(address, port);
+                socket.Connect(rep);
+            }
+        }
+
+        /// <summary>
+        /// Close open socket
+        /// </summary>
+        public static void CloseUdpSocket()
+        {
+            socket.Close();
+            socket = null;
+        }
+
+        /// <summary>
+        /// Send message to specific target / port
+        /// </summary>
+        /// <param name="port">Port number to send to</param>
+        /// <param name="targetAdr">Target IP address</param>
+        /// <param name="message">MEssage to send</param>
+        public static void SendMessageSocketTo(int port, string targetAdr, string message)
+        {
+            var data = Encoding.UTF8.GetBytes(message);
+
+            var address = IPAddress.Parse(targetAdr);
+            IPEndPoint ep = new IPEndPoint(address, port);
+
+            socket.SendTo(data, ep);
+        }
+
+        /// <summary>
+        /// Send message to connected target, target specified in Open
+        /// </summary>
+        /// <param name="message"></param>
+        public static void SendMessage(string message)
+        {
+            var data = Encoding.UTF8.GetBytes(message);
+            socket.Send(data);
+        }
+
+        /// <summary>
+        /// Method for receiving and displaying messages from UDP socket. 
+        /// If respond param true will respond with generic message (like a server)
+        /// </summary>
+        /// <param name="respond"></param>
+        public static void ReceiveUdpMessages(bool respond = false)
+        {
+            Display.Log($"Receive thread for UDP messages started");
+
+            while (true)
+            {
+                byte[] data = new byte[256];
+                EndPoint remoteEp = new IPEndPoint(0, 0);
+
+                int length = socket.ReceiveFrom(data, ref remoteEp);
+
+                var message = Encoding.UTF8.GetString(data, 0, length);
+
+                Display.Log($"UDP message(sock) >{message}< received from {remoteEp}");
+
+                Program.Led.SetRxTX();
+
+                if (respond)
+                {
+                    IPEndPoint rp = remoteEp as IPEndPoint;
+                    SendMessageSocketTo(rp.Port, rp.Address.ToString(), $"Server response {DateTime.UtcNow}");
+                    Display.Log($"UDP message(sock) >{message}< respond to {rp.Address} {rp.Port}");
+                }
+            }
+        }
+    }
+}

--- a/samples/OpenThread/SocketUtils.cs
+++ b/samples/OpenThread/SocketUtils.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.Net.Sockets;
 using System.Net;
 using System.Text;
@@ -86,7 +91,7 @@ namespace Samples
 
                 Display.Log($"UDP message(sock) >{message}< received from {remoteEp}");
 
-                Program.Led.SetRxTX();
+                Program._led.SetRxTX();
 
                 if (respond)
                 {

--- a/samples/OpenThread/UdpThreadClient/Program.cs
+++ b/samples/OpenThread/UdpThreadClient/Program.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Threading;
+using System.Net;
+using nanoFramework.Networking.Thread;
+
+namespace Samples
+{
+    public class Program
+    {
+        const int UDP_PORT = 1234;
+
+        static OpenThread ot;
+        static AutoResetEvent WaitNetAttached = new AutoResetEvent(false);
+
+        public static Led Led = new Led();
+
+        public static void Main()
+        {
+            Console.WriteLine();
+            Display.Log("Sample UDP thread UDP client");
+
+            try
+            {
+                // Target is mesh broadcast address
+                // this will be received by all mesh devices except sleepy devices.
+                // If you use a specific mesh local address here it will only received by 1 target
+                string remoteAdress = "ff03::1";
+
+                Led.Set(ThreadDeviceRole.Disabled);
+
+                // Initialize OpenThread stack
+                InitThread();
+
+                Display.Log("Wait for OpenThread to be attached...");
+                WaitNetAttached.WaitOne();
+
+                IPAddress meshLocal = ot.MeshLocalAddress;
+                Display.Log($"Own mesh local IPV6 address {meshLocal}");
+
+                Display.Log("Display current active dataset");
+                CommandAndResult("dataset active");
+
+                Display.Log("Display interface IP addresses");
+                CommandAndResult("ipaddr");
+
+                Display.Log("Open UDP socket for communication");
+                NetUtils.OpenUdpSocket("", UDP_PORT, ot.MeshLocalAddress);
+
+                Display.Log("Start a receive thread for UDP message responses");
+                Thread ReceiveUdpthread = new Thread(() => NetUtils.ReceiveUdpMessages());
+                ReceiveUdpthread.Start();
+
+                while (true)
+                {
+                    Display.Log($"Send (broadcast) messages on port:{UDP_PORT}");
+                    NetUtils.SendMessageSocketTo(UDP_PORT, remoteAdress, $"Test message via socket @ {DateTime.UtcNow}");
+                    Led.SetRxTX();
+
+                    Thread.Sleep(5000);
+                }
+            }
+            catch (Exception e)
+            {
+                Display.Log($"Exception : {e.Message}");
+                Display.Log($"Stack : {e.StackTrace}");
+            }
+
+            Thread.Sleep(Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Initialize the OpenThread
+        /// </summary>
+        static void InitThread()
+        {
+            OpenThreadDataset data = new OpenThreadDataset()
+            {
+                // Minimum data required to set up/connect to Thread network
+                NetworkName = "nanoFramework",
+                // 000102030405060708090A0B0C0D0E0F
+                NetworkKey = new byte[16] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+                PanId = 0x1234,
+                Channel = 15
+            };
+
+            Display.Log("---- Thread Dataset ------");
+            Display.Log($"Network name {data.NetworkName}");
+            Display.Log($"NetworkKey   {BitConverter.ToString(data.NetworkKey)}");
+            Display.Log($"Channel      {data.Channel}");
+            Display.Log("---- Thread Dataset end ------");
+
+            // Use local radio, ESP32_C6 or ESP32_H2
+            ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
+
+            // Set up event handlers
+            ot.OnStatusChanged += Ot_OnStatusChanged;
+            ot.OnRoleChanged += Ot_OnRoleChanged;
+            ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
+
+            ot.Dataset = data;
+
+            Display.Log($"Starting OpenThread stack");
+            ot.Start();
+
+            Display.Log($"Current Role");
+            Display.Role(ot.Role);
+        }
+
+        static void CommandAndResult(string cmd)
+        {
+            Console.WriteLine($"{Display.LH} command>{cmd}");
+            string[] results = ot.CommandLineInputAndWaitResponse(cmd);
+            Display.Log(results);
+        }
+
+        #region OpenThread events handlers
+
+        private static void Ot_OnConsoleOutputAvailable(OpenThread sender, OpenThreadConsoleOutputAvailableArgs args)
+        {
+            Display.Log(args.consoleLines);
+        }
+
+        private static void Ot_OnRoleChanged(OpenThread sender, OpenThreadRoleChangeEventArgs args)
+        {
+            Display.Role(args.currentRole);
+            Led.Set(args.currentRole);
+        }
+
+        private static void Ot_OnStatusChanged(OpenThread sender, OpenThreadStateChangeEventArgs args)
+        {
+            switch ((ThreadDeviceState)args.currentState)
+            {
+                case ThreadDeviceState.Detached:
+                    Display.Log("Status - Detached");
+                    break;
+
+                case ThreadDeviceState.Attached:
+                    Display.Log("Status - Attached");
+                    WaitNetAttached.Set();
+                    break;
+
+                case ThreadDeviceState.GotIpv6:
+                    Display.Log("Status - Got IPV6 address");
+                    break;
+
+                case ThreadDeviceState.Start:
+                    Display.Log("Status - Started");
+                    break;
+
+                case ThreadDeviceState.Stop:
+                    Display.Log("Status - Stopped");
+                    break;
+
+                case ThreadDeviceState.InterfaceUp:
+                    Display.Log("Status - Interface UP");
+                    break;
+
+                case ThreadDeviceState.InterfaceDown:
+                    Display.Log("Status - Interface DOWN");
+                    break;
+
+                default:
+                    Display.Log($"Status - changed to {args.currentState}");
+                    break;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/samples/OpenThread/UdpThreadClient/Program.cs
+++ b/samples/OpenThread/UdpThreadClient/Program.cs
@@ -1,3 +1,8 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Threading;
 using System.Net;
@@ -7,12 +12,12 @@ namespace Samples
 {
     public class Program
     {
-        const int UDP_PORT = 1234;
+        private const int UDP_PORT = 1234;
 
-        static OpenThread ot;
-        static AutoResetEvent WaitNetAttached = new AutoResetEvent(false);
+        private static OpenThread _ot;
+        private static AutoResetEvent _waitNetAttached = new AutoResetEvent(false);
 
-        public static Led Led = new Led();
+        public static Led _led = new Led();
 
         public static void Main()
         {
@@ -26,15 +31,15 @@ namespace Samples
                 // If you use a specific mesh local address here it will only received by 1 target
                 string remoteAdress = "ff03::1";
 
-                Led.Set(ThreadDeviceRole.Disabled);
+                _led.Set(ThreadDeviceRole.Disabled);
 
                 // Initialize OpenThread stack
                 InitThread();
 
                 Display.Log("Wait for OpenThread to be attached...");
-                WaitNetAttached.WaitOne();
+                _waitNetAttached.WaitOne();
 
-                IPAddress meshLocal = ot.MeshLocalAddress;
+                IPAddress meshLocal = _ot.MeshLocalAddress;
                 Display.Log($"Own mesh local IPV6 address {meshLocal}");
 
                 Display.Log("Display current active dataset");
@@ -44,7 +49,7 @@ namespace Samples
                 CommandAndResult("ipaddr");
 
                 Display.Log("Open UDP socket for communication");
-                NetUtils.OpenUdpSocket("", UDP_PORT, ot.MeshLocalAddress);
+                NetUtils.OpenUdpSocket("", UDP_PORT, _ot.MeshLocalAddress);
 
                 Display.Log("Start a receive thread for UDP message responses");
                 Thread ReceiveUdpthread = new Thread(() => NetUtils.ReceiveUdpMessages());
@@ -54,7 +59,7 @@ namespace Samples
                 {
                     Display.Log($"Send (broadcast) messages on port:{UDP_PORT}");
                     NetUtils.SendMessageSocketTo(UDP_PORT, remoteAdress, $"Test message via socket @ {DateTime.UtcNow}");
-                    Led.SetRxTX();
+                    _led.SetRxTX();
 
                     Thread.Sleep(5000);
                 }
@@ -90,26 +95,26 @@ namespace Samples
             Display.Log("---- Thread Dataset end ------");
 
             // Use local radio, ESP32_C6 or ESP32_H2
-            ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
+            _ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
 
             // Set up event handlers
-            ot.OnStatusChanged += Ot_OnStatusChanged;
-            ot.OnRoleChanged += Ot_OnRoleChanged;
-            ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
+            _ot.OnStatusChanged += Ot_OnStatusChanged;
+            _ot.OnRoleChanged += Ot_OnRoleChanged;
+            _ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
 
-            ot.Dataset = data;
+            _ot.Dataset = data;
 
             Display.Log($"Starting OpenThread stack");
-            ot.Start();
+            _ot.Start();
 
             Display.Log($"Current Role");
-            Display.Role(ot.Role);
+            Display.Role(_ot.Role);
         }
 
         static void CommandAndResult(string cmd)
         {
             Console.WriteLine($"{Display.LH} command>{cmd}");
-            string[] results = ot.CommandLineInputAndWaitResponse(cmd);
+            string[] results = _ot.CommandLineInputAndWaitResponse(cmd);
             Display.Log(results);
         }
 
@@ -123,7 +128,7 @@ namespace Samples
         private static void Ot_OnRoleChanged(OpenThread sender, OpenThreadRoleChangeEventArgs args)
         {
             Display.Role(args.currentRole);
-            Led.Set(args.currentRole);
+            _led.Set(args.currentRole);
         }
 
         private static void Ot_OnStatusChanged(OpenThread sender, OpenThreadStateChangeEventArgs args)
@@ -136,7 +141,7 @@ namespace Samples
 
                 case ThreadDeviceState.Attached:
                     Display.Log("Status - Attached");
-                    WaitNetAttached.Set();
+                    _waitNetAttached.Set();
                     break;
 
                 case ThreadDeviceState.GotIpv6:

--- a/samples/OpenThread/UdpThreadClient/Properties/AssemblyInfo.cs
+++ b/samples/OpenThread/UdpThreadClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UdpThreadClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UdpThreadClient")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/OpenThread/UdpThreadClient/UdpThreadClient.nfproj
+++ b/samples/OpenThread/UdpThreadClient/UdpThreadClient.nfproj
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>c679edd8-8104-4188-b1e3-a7b84c5b7e7b</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>UdpThreadSamples</RootNamespace>
+    <AssemblyName>UdpThreadSamples</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="..\Display.cs">
+      <Link>Display.cs</Link>
+    </Compile>
+    <Compile Include="..\Led.cs">
+      <Link>Led.cs</Link>
+    </Compile>
+    <Compile Include="..\SocketUtils.cs">
+      <Link>SocketUtils.cs</Link>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CCSWE.nanoFramework.Math">
+      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.32\lib\CCSWE.nanoFramework.Math.dll</HintPath>
+    </Reference>
+    <Reference Include="CCSWE.nanoFramework.NeoPixel">
+      <HintPath>..\packages\CCSWE.nanoFramework.NeoPixel.1.0.41\lib\CCSWE.nanoFramework.NeoPixel.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Graphics.Core">
+      <HintPath>..\packages\nanoFramework.Graphics.Core.1.2.15\lib\nanoFramework.Graphics.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.15\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32.Rmt">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.Rmt.2.0.10\lib\nanoFramework.Hardware.Esp32.Rmt.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Networking.Thread">
+      <HintPath>..\packages\nanoFramework.Networking.Thread.1.0.10\lib\nanoFramework.Networking.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Native">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.6.12\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.1.41\lib\System.Device.Gpio.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Math">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net">
+      <HintPath>..\packages\nanoFramework.System.Net.1.10.79\lib\System.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading">
+      <HintPath>..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/samples/OpenThread/UdpThreadClient/packages.config
+++ b/samples/OpenThread/UdpThreadClient/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CCSWE.nanoFramework.Math" version="0.1.32" targetFramework="netnano1.0" />
+  <package id="CCSWE.nanoFramework.NeoPixel" version="1.0.41" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Graphics.Core" version="1.2.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.10" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Networking.Thread" version="1.0.10" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.41" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.79" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
+</packages>

--- a/samples/OpenThread/UdpThreadSamples.sln
+++ b/samples/OpenThread/UdpThreadSamples.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34221.43
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "UdpThreadClient", "UdpThreadClient\UdpThreadClient.nfproj", "{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "UdpThreadServer", "UdpThreadServer\UdpThreadServer.nfproj", "{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{2B0FD5A8-FC86-4111-8B70-2B0D7090F468}"
+	ProjectSection(SolutionItems) = preProject
+		Display.cs = Display.cs
+		Led.cs = Led.cs
+		SocketUtils.cs = SocketUtils.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{581E3239-0AE5-4403-B31C-C91265E4AA5E}"
+	ProjectSection(SolutionItems) = preProject
+		category.txt = category.txt
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C679EDD8-8104-4188-B1E3-A7B84C5B7E7B}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA37527A-FC52-4269-A9B1-ACC366ECD0C5}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5BE944EC-96F1-4350-88E2-C133969F1FC8}
+	EndGlobalSection
+EndGlobal

--- a/samples/OpenThread/UdpThreadServer/Program.cs
+++ b/samples/OpenThread/UdpThreadServer/Program.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Net;
+using System.Threading;
+using nanoFramework.Networking.Thread;
+
+namespace Samples
+{
+    public class Program
+    {
+        const int UDP_PORT = 1234;
+
+        static OpenThread ot;
+        static AutoResetEvent WaitNetAttached = new AutoResetEvent(false);
+        
+        public static Led Led = new Led();
+
+        public static void Main()
+        {
+            Console.WriteLine();
+            Display.Log("Sample UDP thread UDP server");
+
+            Display.LogMemoryStats("Start up");
+
+            Led.Set(ThreadDeviceRole.Disabled);
+
+            // Init OpenThread stack
+            InitThread();
+
+            Display.Log("Wait for OpenThread to be attached...");
+            WaitNetAttached.WaitOne();
+
+            Display.Log("== Demonstrate some CLI commands");
+            Display.Log("- Display current active dataset");
+            CommandAndResult("dataset active");
+
+            Display.Log("Display interface IP addresses");
+            CommandAndResult("ipaddr");
+
+            IPAddress adr = ot.MeshLocalAddress;
+            Display.Log($"Local Mesh address {adr}");
+
+            Display.Log("Open UDP socket for communication");
+            NetUtils.OpenUdpSocket("", UDP_PORT, IPAddress.IPv6Any);
+
+            Display.Log("Start a receive thread to respond to UDP messages");
+            Thread ReceiveUdpThread = new Thread(() => NetUtils.ReceiveUdpMessages(true));
+            ReceiveUdpThread.Start();
+
+            Thread.Sleep(Timeout.Infinite);
+        }
+
+        static void CommandAndResult(string cmd)
+        {
+            Console.WriteLine($"{Display.LH} command>{cmd}");
+            string[] results = ot.CommandLineInputAndWaitResponse(cmd);
+            Display.Log(results);
+        }
+
+        #region OpenThread
+
+        /// <summary>
+        /// Initialize the OpenThread
+        /// </summary>
+        static void InitThread()
+        {
+            OpenThreadDataset data = new OpenThreadDataset()
+            {
+                // Minimum data required to set up/connect to Thread network
+                NetworkName = "nanoFramework",
+                // 000102030405060708090A0B0C0D0E0F
+                NetworkKey = new byte[16] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+                PanId = 0x1234,
+                Channel = 15
+            };
+
+            Display.Log("---- Thread Dataset ------");
+            Display.Log($"Network name {data.NetworkName}");
+            Display.Log($"NetworkKey   {BitConverter.ToString(data.NetworkKey)}");
+            Display.Log($"Channel      {data.Channel}");
+            Display.Log("---- Thread Dataset end ------");
+
+            // Use local radio, ESP32_C6 or ESP32_H2
+            ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
+
+            // Set up event handlers
+            ot.OnStatusChanged += Ot_OnStatusChanged;
+            ot.OnRoleChanged += Ot_OnRoleChanged;
+            ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
+
+            ot.Dataset = data;
+
+            Display.Log($"Starting OpenThread stack");
+            ot.Start();
+        }
+
+        private static void Ot_OnRoleChanged(OpenThread sender, OpenThreadRoleChangeEventArgs args)
+        {
+            Display.Role(args.currentRole);
+            Led.Set(args.currentRole);
+        }
+
+        private static void Ot_OnStatusChanged(OpenThread sender, OpenThreadStateChangeEventArgs args)
+        {
+            switch ((ThreadDeviceState)args.currentState)
+            {
+                case ThreadDeviceState.Detached:
+                    Display.Log("Status - Detached");
+                    Led.Set(ThreadDeviceRole.Disabled);
+                    break;
+
+                case ThreadDeviceState.Attached:
+                    Display.Log("Status - Attached");
+                    WaitNetAttached.Set();
+                    break;
+
+                case ThreadDeviceState.GotIpv6:
+                    Display.Log("Status - Got IPV6 address");
+                    break;
+
+                case ThreadDeviceState.Start:
+                    Display.Log("Status - Started");
+                    break;
+
+                case ThreadDeviceState.Stop:
+                    Display.Log("Status - Stopped");
+                    break;
+
+                case ThreadDeviceState.InterfaceUp:
+                    Display.Log("Status - Interface UP");
+                    break;
+
+                case ThreadDeviceState.InterfaceDown:
+                    Display.Log("Status - Interface DOWN");
+                    break;
+
+                default:
+                    Display.Log($"Status - changed to {args.currentState}");
+                    break;
+            }
+        }
+        private static void Ot_OnConsoleOutputAvailable(OpenThread sender, OpenThreadConsoleOutputAvailableArgs args)
+        {
+            Display.Log(args.consoleLines);
+        }
+
+        #endregion
+    }
+}

--- a/samples/OpenThread/UdpThreadServer/Program.cs
+++ b/samples/OpenThread/UdpThreadServer/Program.cs
@@ -1,3 +1,8 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Net;
 using System.Threading;
@@ -7,12 +12,12 @@ namespace Samples
 {
     public class Program
     {
-        const int UDP_PORT = 1234;
+        private const int UDP_PORT = 1234;
 
-        static OpenThread ot;
-        static AutoResetEvent WaitNetAttached = new AutoResetEvent(false);
+        private static OpenThread _ot;
+        private static AutoResetEvent _waitNetAttached = new AutoResetEvent(false);
         
-        public static Led Led = new Led();
+        public static Led _led = new Led();
 
         public static void Main()
         {
@@ -21,13 +26,13 @@ namespace Samples
 
             Display.LogMemoryStats("Start up");
 
-            Led.Set(ThreadDeviceRole.Disabled);
+            _led.Set(ThreadDeviceRole.Disabled);
 
             // Init OpenThread stack
             InitThread();
 
             Display.Log("Wait for OpenThread to be attached...");
-            WaitNetAttached.WaitOne();
+            _waitNetAttached.WaitOne();
 
             Display.Log("== Demonstrate some CLI commands");
             Display.Log("- Display current active dataset");
@@ -36,7 +41,7 @@ namespace Samples
             Display.Log("Display interface IP addresses");
             CommandAndResult("ipaddr");
 
-            IPAddress adr = ot.MeshLocalAddress;
+            IPAddress adr = _ot.MeshLocalAddress;
             Display.Log($"Local Mesh address {adr}");
 
             Display.Log("Open UDP socket for communication");
@@ -52,7 +57,7 @@ namespace Samples
         static void CommandAndResult(string cmd)
         {
             Console.WriteLine($"{Display.LH} command>{cmd}");
-            string[] results = ot.CommandLineInputAndWaitResponse(cmd);
+            string[] results = _ot.CommandLineInputAndWaitResponse(cmd);
             Display.Log(results);
         }
 
@@ -80,23 +85,23 @@ namespace Samples
             Display.Log("---- Thread Dataset end ------");
 
             // Use local radio, ESP32_C6 or ESP32_H2
-            ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
+            _ot = OpenThread.CreateThreadWithNativeRadio(ThreadDeviceType.Router);
 
             // Set up event handlers
-            ot.OnStatusChanged += Ot_OnStatusChanged;
-            ot.OnRoleChanged += Ot_OnRoleChanged;
-            ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
+            _ot.OnStatusChanged += Ot_OnStatusChanged;
+            _ot.OnRoleChanged += Ot_OnRoleChanged;
+            _ot.OnConsoleOutputAvailable += Ot_OnConsoleOutputAvailable;
 
-            ot.Dataset = data;
+            _ot.Dataset = data;
 
             Display.Log($"Starting OpenThread stack");
-            ot.Start();
+            _ot.Start();
         }
 
         private static void Ot_OnRoleChanged(OpenThread sender, OpenThreadRoleChangeEventArgs args)
         {
             Display.Role(args.currentRole);
-            Led.Set(args.currentRole);
+            _led.Set(args.currentRole);
         }
 
         private static void Ot_OnStatusChanged(OpenThread sender, OpenThreadStateChangeEventArgs args)
@@ -105,12 +110,12 @@ namespace Samples
             {
                 case ThreadDeviceState.Detached:
                     Display.Log("Status - Detached");
-                    Led.Set(ThreadDeviceRole.Disabled);
+                    _led.Set(ThreadDeviceRole.Disabled);
                     break;
 
                 case ThreadDeviceState.Attached:
                     Display.Log("Status - Attached");
-                    WaitNetAttached.Set();
+                    _waitNetAttached.Set();
                     break;
 
                 case ThreadDeviceState.GotIpv6:

--- a/samples/OpenThread/UdpThreadServer/Properties/AssemblyInfo.cs
+++ b/samples/OpenThread/UdpThreadServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UdpThreadServer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UdpThreadServer")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/OpenThread/UdpThreadServer/UdpThreadServer.nfproj
+++ b/samples/OpenThread/UdpThreadServer/UdpThreadServer.nfproj
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>ea37527a-fc52-4269-a9b1-acc366ecd0c5</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>UdpThreadServer</RootNamespace>
+    <AssemblyName>UdpThreadServer</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="..\Display.cs">
+      <Link>Display.cs</Link>
+    </Compile>
+    <Compile Include="..\Led.cs">
+      <Link>Led.cs</Link>
+    </Compile>
+    <Compile Include="..\SocketUtils.cs">
+      <Link>SocketUtils.cs</Link>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CCSWE.nanoFramework.Math">
+      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.32\lib\CCSWE.nanoFramework.Math.dll</HintPath>
+    </Reference>
+    <Reference Include="CCSWE.nanoFramework.NeoPixel">
+      <HintPath>..\packages\CCSWE.nanoFramework.NeoPixel.1.0.41\lib\CCSWE.nanoFramework.NeoPixel.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Graphics.Core">
+      <HintPath>..\packages\nanoFramework.Graphics.Core.1.2.15\lib\nanoFramework.Graphics.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.15\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32.Rmt">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.Rmt.2.0.10\lib\nanoFramework.Hardware.Esp32.Rmt.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Networking.Thread">
+      <HintPath>..\packages\nanoFramework.Networking.Thread.1.0.10\lib\nanoFramework.Networking.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Native">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.6.12\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.1.41\lib\System.Device.Gpio.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Math">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net">
+      <HintPath>..\packages\nanoFramework.System.Net.1.10.79\lib\System.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading">
+      <HintPath>..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/samples/OpenThread/UdpThreadServer/packages.config
+++ b/samples/OpenThread/UdpThreadServer/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CCSWE.nanoFramework.Math" version="0.1.32" targetFramework="netnano1.0" />
+  <package id="CCSWE.nanoFramework.NeoPixel" version="1.0.41" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Graphics.Core" version="1.2.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.10" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Networking.Thread" version="1.0.10" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.41" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.79" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
+</packages>

--- a/samples/OpenThread/category.txt
+++ b/samples/OpenThread/category.txt
@@ -1,0 +1,1 @@
+networking


### PR DESCRIPTION
## Description

Adds 2 samples for OpenThread using Udp sockets over IPV6
- UdpThreadClient
- UdpThreadServer

## Motivation and Context
Required to go with OpenThread assembly.


## How Has This Been Tested?<!-- (if applicable) -->

Tested locally with 5 x esp32_c6,  2 x esp32_h2 and espressif border router


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a sample)
- [ ] Bug fix (fixes an issue with a current sample)
- [x] New Sample (adds a new sample)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new marker file for categorizing content related to "networking."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->