### PR TITLE
Add I2C slave sample

### DIFF
--- a/samples/I2C/I2cMasterSlave/I2cMasterDevice/I2cMasterDevice.nfproj
+++ b/samples/I2C/I2cMasterSlave/I2cMasterDevice/I2cMasterDevice.nfproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>ae6817bf-dd2a-4883-aba7-0a90751304b7</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Samples.I2c.MasterDevice</RootNamespace>
+    <AssemblyName>I2cMasterDevice</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.19\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.I2c">
+      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.1.16\lib\System.Device.I2c.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/samples/I2C/I2cMasterSlave/I2cMasterDevice/Program.cs
+++ b/samples/I2C/I2cMasterSlave/I2cMasterDevice/Program.cs
@@ -1,0 +1,64 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Device.I2c;
+using System.Diagnostics;
+using System.Threading;
+using nanoFramework.Hardware.Esp32;
+
+namespace Samples.I2c.MasterDevice
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            // Configure I2C GPIO pins
+            Configuration.SetPinFunction(Gpio.IO18, DeviceFunction.I2C1_DATA);
+            Configuration.SetPinFunction(Gpio.IO19, DeviceFunction.I2C1_CLOCK);
+
+            // create I2C device
+            var myI2cDevice = I2cDevice.Create(new I2cConnectionSettings(
+                1,
+                0x10,
+                I2cBusSpeed.FastMode));
+
+            // setup read buffer
+            var buffer = new byte[2];
+
+            while (true)
+            {
+                try
+                {
+                    // set address to read from
+                    if (myI2cDevice.Write(new byte[] { 0x22 }).BytesTransferred != 1)
+                    {
+                        Debug.WriteLine("Error writting to I2C device to set register address to read from");
+                    }
+                    else
+                    {
+                        if (myI2cDevice.Read(buffer).BytesTransferred != 2)
+                        {
+                            Debug.WriteLine("Error reading from I2C device");
+                        }
+                        else
+                        {
+
+                            // expected buffer content is: 0xBE, 0xEF
+                            Debug.WriteLine($"Register content: {buffer[0]:X2} {buffer[1]:X2}");
+                        }
+                    }
+
+                    // pause before a new read
+                    Thread.Sleep(1000);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error reading from I2C device: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/samples/I2C/I2cMasterSlave/I2cMasterDevice/Properties/AssemblyInfo.cs
+++ b/samples/I2C/I2cMasterSlave/I2cMasterDevice/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSharp.I2cMasterDevice")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/samples/I2C/I2cMasterSlave/I2cMasterDevice/packages.config
+++ b/samples/I2C/I2cMasterSlave/I2cMasterDevice/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.19" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.I2c" version="1.1.16" targetFramework="netnano1.0" />
+</packages>

--- a/samples/I2C/I2cMasterSlave/I2cMasterSlave.sln
+++ b/samples/I2C/I2cMasterSlave/I2cMasterSlave.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34928.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1F0B41A0-B2F5-4986-95D9-8D91623B69C9}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "I2cMasterDevice", "I2cMasterDevice\I2cMasterDevice.nfproj", "{AE6817BF-DD2A-4883-ABA7-0A90751304B7}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "I2cSlaveDevice", "I2cSlaveDevice\I2cSlaveDevice.nfproj", "{EDFF1C28-7988-4360-A0EF-2008E57945C6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE6817BF-DD2A-4883-ABA7-0A90751304B7}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDFF1C28-7988-4360-A0EF-2008E57945C6}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5834D1F4-7FFC-4363-AA2D-8AA473993BCF}
+	EndGlobalSection
+EndGlobal

--- a/samples/I2C/I2cMasterSlave/I2cSlaveDevice/I2cSlaveDevice.nfproj
+++ b/samples/I2C/I2cMasterSlave/I2cSlaveDevice/I2cSlaveDevice.nfproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>edff1c28-7988-4360-a0ef-2008e57945c6</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Samples.I2c.SlaveDevice</RootNamespace>
+    <AssemblyName>I2cSlaveDevice</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.19\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.I2c.Slave">
+      <HintPath>..\packages\nanoFramework.System.Device.I2c.Slave.1.0.10\lib\System.Device.I2c.Slave.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/samples/I2C/I2cMasterSlave/I2cSlaveDevice/Program.cs
+++ b/samples/I2C/I2cMasterSlave/I2cSlaveDevice/Program.cs
@@ -1,0 +1,49 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Device.I2c;
+using System.Diagnostics;
+using nanoFramework.Hardware.Esp32;
+
+namespace Samples.I2c.SlaveDevice
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            Configuration.SetPinFunction(Gpio.IO18, DeviceFunction.I2C1_DATA);
+            Configuration.SetPinFunction(Gpio.IO19, DeviceFunction.I2C1_CLOCK);
+
+            // create an I2C slave device on bus 1 with address 0x10
+            var device = new I2cSlaveDevice(1, 0x10);
+
+            while (true)
+            {
+                // wait "forever" for a single byte
+                try
+                {
+                    if (device.ReadByte(out byte registerAddress, 500))
+                    {
+                        switch (registerAddress)
+                        {
+                            case 0x22:
+                                // reply back with 2 dummy bytes
+                                device.Write(new byte[] { 0xBE, 0xEF });
+
+                                Debug.WriteLine($"Received message: {registerAddress:X2}");
+
+                                break;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Timeout I2C device");
+                }
+            }
+        }
+    }
+}

--- a/samples/I2C/I2cMasterSlave/I2cSlaveDevice/Properties/AssemblyInfo.cs
+++ b/samples/I2C/I2cMasterSlave/I2cSlaveDevice/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSharp.I2cSlaveDevice")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/samples/I2C/I2cMasterSlave/I2cSlaveDevice/packages.config
+++ b/samples/I2C/I2cMasterSlave/I2cSlaveDevice/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.19" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.I2c.Slave" version="1.0.10" targetFramework="netnano1.0" />
+</packages>

--- a/samples/I2C/I2cMasterSlave/README.md
+++ b/samples/I2C/I2cMasterSlave/README.md
@@ -1,10 +1,18 @@
-# 🌶️🌶️ - I2C sample sample pack
+# 🌶️🌶️ - I2C Master Slave sample
 
-## System.Device.I2c
+Shows how to use the [System.Device.I2c](http://docs.nanoframework.net/api/System.Device.I2c.html) [System.Device.I2c.Slave](http://docs.nanoframework.net/api/System.Device.I2c.Slave.html) APIs to connect two I2C devices.
 
-- [🌶️🌶️ - IES-SHIELD-GPS module](./System.Device.I2c/GPS)
-- [🌶️🌶️ - I2C Scanner sample](./NanoI2cScanner/)
-- [🌶️🌶️ - I2C Master - Slave sample](./I2cMasterSlave/)
+## Hardware requirements
+
+Two ESP32 devices board.
+The code sample is demonstrative of the use of the I2C and I2C slave APIs.
+
+## Related topics
+
+### Reference
+
+- [System.Device.I2c](http://docs.nanoframework.net/api/System.Device.I2c.html)
+- [System.Device.I2c.Slave](http://docs.nanoframework.net/api/System.Device.I2c.Slave.html)
 
 ## Build the sample
 


### PR DESCRIPTION
## Description
- Add sample projects for both slave and master devices.
- Update main readme for I2C.

## Motivation and Context
- I2C slave sample missing.
- Addresses nanoFramework/Home#1494.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a sample)
- [ ] Bug fix (fixes an issue with a current sample)
- [x] New Sample (adds a new sample)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
